### PR TITLE
remove hnssearch searchbar (hnssearch not working)

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
 <nav class="navbar navbar-light" style="background-color: #e3f2fd; margin: auto; height: 80px;">
   <a class="navbar-brand" href="#"><img src="banners/HNSlogo.png" width="30 px" height="30" alt="all about handshake" ></a>
     <span class="navbar-text" style="color: red;">All About Handshake</span>
-    <iframe  src="https://1008m5ja18rks0lfcp00cqaq3hunrmhhgtlgv59f8lips03tlp1ks9g.siasky.net/"  style="overflow: hidden; margin: 0; padding: 0; width: 800px; height: 60px; float: right;"  frameborder="0"></iframe>
     <iframe src="https://siasky.net/AAB-kFKVC60w7QYfh1GgMKAiciy4mzQ4IHI3ZwcEuWTuPQ" style="overflow:hidden; margin: 0; padding: 0; width:800px; height:60px; border-radius: 10px; float: left;" frameborder="0"></iframe>
 </nav>
     <!--Banner-->


### PR DESCRIPTION
Removed the HNSSearch search bar iframe at the top of the website as the HNSSearch Beta finished and the website is down for a couple of months.